### PR TITLE
chore: change naming to avoid confusion with storyblok official tooling

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ builds:
     binary: sbsync
     env:
       - CGO_ENABLED=0
-    goos: [linux, darwin, windows]
+    goos: [linux, darwin]
     goarch: [amd64, arm64]
     flags:
       - -trimpath
@@ -16,9 +16,6 @@ builds:
 archives:
   - id: default
     builds: [sbsync]
-    format_overrides:
-      - goos: windows
-        format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
     files:
       - README.md
@@ -40,4 +37,3 @@ changelog:
 
 release:
   prerelease: auto
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,13 @@
 - `go vet ./...`: Static checks for common mistakes.
 - `go test ./...`: Run the full test suite. Add `-cover` for coverage.
 
+Recommended local hooks (optional):
+
+- Enable: `git config core.hooksPath scripts/githooks && chmod +x scripts/githooks/*`
+- pre-commit: formats staged Go files; runs `go vet` and `staticcheck` on affected packages.
+- pre-push: runs `go test -race -cover ./...`.
+- Install staticcheck: `go install honnef.co/go/tools/cmd/staticcheck@latest`.
+
 ## Coding Style & Naming Conventions
 - **Language:** Go 1.25; identifiers and comments in English. User‑facing strings may be German.
 - **Formatting:** Use `go fmt` (tabs). Group imports: stdlib, third‑party, internal.
@@ -38,4 +45,3 @@
 
 ## Architecture Notes
 - Bubble Tea MVU for UI (`internal/ui`) with business logic and Storyblok access decoupled (`internal/sb`). Keep future domain logic under `internal/core/` to maintain clear boundaries.
-

--- a/README.md
+++ b/README.md
@@ -277,6 +277,15 @@ The sync core has been extracted to `internal/core/sync`. Future modules (`infra
 
 See [AGENTS.md](AGENTS.md) for coding conventions and testing requirements. Submit pull requests with a short description of the change and note any deviations from the guidelines.
 
+## Git Hooks
+
+Optional local hooks for fast feedback:
+
+- Install: `git config core.hooksPath scripts/githooks && chmod +x scripts/githooks/*`
+- Pre-commit: formats staged Go files, then runs `go vet` and `staticcheck` on affected packages.
+- Pre-push: runs `go test -race -cover ./...`.
+- Note: install staticcheck locally with `go install honnef.co/go/tools/cmd/staticcheck@latest`.
+
 ## License
 
 Licensed under the GNU General Public License, version 3 (GPL-3.0). See `LICENSE` for details.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Storyblok Sync TUI
+# sbsync – a TUI for syncing Storyblok spaces
 
-Storyblok Sync is a terminal user interface (TUI) that synchronises Stories, Folders, and Components between two Storyblok spaces. It lets you scan source/target, select content, preflight collisions, and apply changes — now including component group mapping, internal tags, and presets.
+sbsync is a terminal user interface (TUI) that synchronises Stories, Folders, and Components between two Storyblok spaces. It lets you scan source/target, select content, preflight collisions, and apply changes — now including component group mapping, internal tags, and presets.
+
+This is an independent open-source project. It is not affiliated with or endorsed by Storyblok GmbH.
 
 See also:
 
@@ -10,6 +12,7 @@ See also:
 
 ## Disclaimer
 
+- This is an independent open-source project and is not affiliated with or endorsed by Storyblok GmbH.
 - This project is under active development; behavior may change and things may break.
 - No warranty, promise of support, or liability is provided. Use at your own risk. I accept no responsibility for unintended outcomes, including data loss.
 - Sync operations can be destructive. Create backups/exports and test in non‑production spaces first where possible.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ There are two supported ways to install `sbsync`:
 
 ### 1) Download a prebuilt binary (recommended)
 
-We publish multi‑platform archives on GitHub Releases via GoReleaser:
+We publish Linux and macOS archives on GitHub Releases via GoReleaser:
 
 - Linux (amd64/arm64): `sbsync_<version>_linux_<arch>.tar.gz`
 - macOS (amd64/arm64): `sbsync_<version>_darwin_<arch>.tar.gz`
-- Windows (amd64/arm64): `sbsync_<version>_windows_<arch>.zip`
+
+Note for Windows users: sbsync does not ship native Windows binaries. Please use WSL2 and follow the Linux instructions inside your WSL environment.
 
 Steps (Linux/macOS):
 
@@ -47,11 +48,6 @@ Steps (Linux/macOS):
    ```sh
    xattr -d com.apple.quarantine /usr/local/bin/sbsync
    ```
-
-Steps (Windows):
-
-1. Download the `.zip` for your architecture.
-2. Extract `sbsync.exe` and add its folder to your `PATH`, or run it directly.
 
 ### 2) Build from source
 
@@ -88,7 +84,7 @@ Notes:
 - The script verifies the `checksums.txt` when possible (requires `sha256sum` or `shasum`).
 - Set `GITHUB_TOKEN` in CI to avoid GitHub API rate limiting when resolving the latest tag.
 - Use `-b "$HOME/.local/bin"` for user‑local installs; add it to your PATH.
-- Windows runners can use the script in GitHub Actions’ bash shell; it downloads the `.zip` and installs `sbsync.exe`.
+- Windows: use WSL2 and run the installer inside your Linux distribution.
 
 ### Quick start
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 sbsync is a terminal user interface (TUI) that synchronises Stories, Folders, and Components between two Storyblok spaces. It lets you scan source/target, select content, preflight collisions, and apply changes — now including component group mapping, internal tags, and presets.
 
-This is an independent open-source project. It is not affiliated with or endorsed by Storyblok GmbH.
+_This is an independent open-source project. It is not affiliated with or endorsed by Storyblok GmbH._
 
 See also:
 
@@ -12,7 +12,6 @@ See also:
 
 ## Disclaimer
 
-- This is an independent open-source project and is not affiliated with or endorsed by Storyblok GmbH.
 - This project is under active development; behavior may change and things may break.
 - No warranty, promise of support, or liability is provided. Use at your own risk. I accept no responsibility for unintended outcomes, including data loss.
 - Sync operations can be destructive. Create backups/exports and test in non‑production spaces first where possible.

--- a/docs/env.md
+++ b/docs/env.md
@@ -6,7 +6,7 @@ This document lists all supported environment variables, what they do, and sensi
 
 - macOS/Linux (temporary): `SB_MA_RPS=6 SB_TUI_GRAPH=1 go run ./cmd/sbsync`
 - macOS/Linux (shell profile): `export SB_MA_RPS=6`
-- Windows PowerShell: `$env:SB_MA_RPS=6`
+- Windows users: Use WSL2 and set env vars inside your Linux distribution as above.
 
 ## Authentication & Config
 

--- a/internal/ui/view_main.go
+++ b/internal/ui/view_main.go
@@ -58,12 +58,12 @@ func (m Model) View() string {
 }
 
 func (m Model) renderHeader() string {
-	var b strings.Builder
-	b.WriteString(titleStyle.Render("Storyblok Sync (TUI)"))
-	b.WriteString("\n")
-	b.WriteString(dividerStyle.Render(strings.Repeat("─", max(10, m.width-2))))
-	b.WriteString("\n")
-	return b.String()
+    var b strings.Builder
+    b.WriteString(titleStyle.Render("sbsync"))
+    b.WriteString("\n")
+    b.WriteString(dividerStyle.Render(strings.Repeat("─", max(10, m.width-2))))
+    b.WriteString("\n")
+    return b.String()
 }
 
 func (m Model) renderFooter() string {

--- a/internal/ui/view_main.go
+++ b/internal/ui/view_main.go
@@ -58,12 +58,12 @@ func (m Model) View() string {
 }
 
 func (m Model) renderHeader() string {
-    var b strings.Builder
-    b.WriteString(titleStyle.Render("sbsync"))
-    b.WriteString("\n")
-    b.WriteString(dividerStyle.Render(strings.Repeat("─", max(10, m.width-2))))
-    b.WriteString("\n")
-    return b.String()
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("sbsync"))
+	b.WriteString("\n")
+	b.WriteString(dividerStyle.Render(strings.Repeat("─", max(10, m.width-2))))
+	b.WriteString("\n")
+	return b.String()
 }
 
 func (m Model) renderFooter() string {

--- a/internal/ui/view_setup.go
+++ b/internal/ui/view_setup.go
@@ -6,8 +6,8 @@ import (
 )
 
 func (m Model) viewWelcome() string {
-	title := titleStyle.Render("🚀 Storyblok Sync")
-	subtitle := subtitleStyle.Render("Synchronisiere Stories zwischen Spaces")
+	title := titleStyle.Render("🚀 sbsync")
+	subtitle := subtitleStyle.Render("Synchronisiere Stories zwischen Storyblok Spaces")
 
 	var statusLines []string
 	if m.cfg.Token != "" {

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run fast checks on staged Go files only: format, vet, staticcheck.
+
+changed_go_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.go$' || true)
+[ -z "$changed_go_files" ] && exit 0
+
+echo "pre-commit: formatting staged Go files..."
+gofmt -s -w $changed_go_files
+git add $changed_go_files
+
+# Derive affected packages from changed files
+pkgs=$(printf '%s\n' "$changed_go_files" \
+  | xargs -n1 dirname | sort -u \
+  | xargs -n1 -I{} bash -c 'go list ./{} 2>/dev/null' \
+  | sort -u)
+
+echo "pre-commit: go vet on affected packages..."
+go vet $pkgs
+
+if command -v staticcheck >/dev/null 2>&1; then
+  echo "pre-commit: staticcheck on affected packages..."
+  staticcheck $pkgs
+else
+  echo "pre-commit: staticcheck not found; install with:" >&2
+  echo "  go install honnef.co/go/tools/cmd/staticcheck@latest" >&2
+fi
+
+echo "pre-commit: OK"
+

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "pre-push: running tests (race, cover)..."
+go test -race -cover ./...
+
+# Optional: uncomment to run extra checks on push
+# echo "pre-push: go vet..."
+# go vet ./...
+# if command -v staticcheck >/dev/null 2>&1; then
+#   echo "pre-push: staticcheck..."
+#   staticcheck ./...
+# fi
+
+echo "pre-push: OK"
+

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,8 +40,7 @@ detect_os() {
   case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
     linux*) echo linux ;;
     darwin*) echo darwin ;;
-    msys*|cygwin*|mingw*) echo windows ;;
-    *) echo "error: unsupported OS" >&2; exit 1 ;;
+    *) echo "error: unsupported OS (supported: linux, darwin). On Windows, please use WSL2." >&2; exit 1 ;;
   esac
 }
 
@@ -135,7 +134,6 @@ main() {
   fi
 
   EXT=tar.gz
-  [ "$OS" = "windows" ] && EXT=zip
   ARCHIVE="sbsync_${VERSION}_${OS}_${ARCH}.${EXT}"
 
   BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
@@ -154,16 +152,9 @@ main() {
   fi
 
   echo "extracting..."
-  if [ "$EXT" = "zip" ]; then
-    need_cmd unzip
-    unzip -q "$tmpdir/$ARCHIVE" -d "$tmpdir"
-    BIN_SRC="$tmpdir/sbsync.exe"
-    BIN_NAME="sbsync.exe"
-  else
-    tar -xzf "$tmpdir/$ARCHIVE" -C "$tmpdir"
-    BIN_SRC="$tmpdir/sbsync"
-    BIN_NAME="sbsync"
-  fi
+  tar -xzf "$tmpdir/$ARCHIVE" -C "$tmpdir"
+  BIN_SRC="$tmpdir/sbsync"
+  BIN_NAME="sbsync"
 
   if [ ! -f "$BIN_SRC" ]; then
     echo "error: extracted binary not found (expected $BIN_SRC)" >&2


### PR DESCRIPTION
- changes name of tool to avoid confusion with official tooling
- adds pre-commit and pre-push hooks for linting
- drops windows support to reduce support surface